### PR TITLE
deblack: reformat against black 26.1.0

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tox-passenv"
 description = "Additional environment variable names to pass into tox test env"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
   "tox >= 3",
 ]
@@ -30,7 +30,6 @@ classifiers = [
   "Topic :: Utilities",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/tox_passenv/_tox4_plugin.py
+++ b/src/tox_passenv/_tox4_plugin.py
@@ -3,7 +3,6 @@ import os
 
 from tox.plugin import impl
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -64,9 +64,7 @@ def test_plugin_usage(tox_project, monkeypatch, passenv_data):
 
     command_template = f"python -c 'import os;{env_vars_commands}'"
 
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -145,9 +143,7 @@ def test_no_plugin_usage(tox_project, monkeypatch, passenv_data):
 
     command_template = f"python -c 'import os;{env_vars_commands}'"
 
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -196,9 +192,7 @@ def test_no_plugin_usage_tox3(tox_project, monkeypatch):
 
     command_template = f"python -c 'import os;{env_vars_commands}'"
 
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]


### PR DESCRIPTION
- reformat against black 26.1.0
- drop support for EOL-d Python 3.9
    
Fixes: https://github.com/stanislavlevin/tox-passenv/issues/4
Fixes: https://github.com/stanislavlevin/tox-passenv/issues/5

## Summary by Sourcery

Reformat code to comply with the latest Black style and drop support for Python 3.9 across configuration and CI.

Enhancements:
- Reformat source and test files to match Black 26.1.0 style guidelines.
- Update project metadata to require Python 3.10+ and adjust supported Python version classifiers.

CI:
- Remove Python 3.9 from GitHub Actions test matrices to align with updated supported Python versions.